### PR TITLE
Add limited test for initial deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "scripts": {
     "test": "npm run lint && nyc ava",
+    "test:initial": "ava --match='*initial*'",
     "watch:test": "ava --watch",
     "lint": "npm run lint:eslint -s",
     "lint:eslint": "eslint $npm_package_config_jsSrc",
     "coverage": "nyc report",
+    "deploy:initial": "npm run test:initial && serverless deploy -v",
     "deploy": "npm test && serverless deploy -v",
     "invoke": "serverless invoke --function sharpImage --path ./event.json --log",
     "postinstall": "if [ ! -f ./config.json ]; then cp ./config.sample.json ./config.json; fi && if [ ! -f ./event.json ]; then cp ./event.sample.json ./event.json; fi",

--- a/src/sharp.test.js
+++ b/src/sharp.test.js
@@ -19,7 +19,7 @@ const options = {
 
 const { all, outputs } = options
 
-test('process input image based on configuration options', async (t) => {
+test('process input image based on configuration options(initial)', async (t) => {
   t.throws(sharpify(undefined, undefined, undefined), TypeError)
 
   const imageStreams = await sharpify(testImage, options, false)

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -4,7 +4,7 @@ import { makeKey, decodeS3EventKey } from './utils'
 
 const { destinationPrefix } = config
 
-test('makeKey()', (t) => {
+test('makeKey() (initial)', (t) => {
   const template = 'magical/unicorns/%(directory)s/%(crumbs[1])s/%(filename)s.%(extension)s'
   const context = { key: 'test1/test2/test3/fancy.png', type: 'image/jpeg' }
   const expected = `${destinationPrefix}magical/unicorns/test1/test2/test3/test2/fancy.jpeg`
@@ -17,7 +17,7 @@ test('makeKey()', (t) => {
   )
 })
 
-test('decodeS3EventKey()', (t) => {
+test('decodeS3EventKey() (initial)', (t) => {
   const undecoded = 'incoming/test+image+%C3%BCtf+%E3%83%86%E3%82%B9%E3%83%88.jpg'
   const expected = 'incoming/test image ütf テスト.jpg'
   const decoded = decodeS3EventKey(undecoded)


### PR DESCRIPTION
I was trying to deploy Sharp lambda function and it fails when I run the test. By default, the test requires existing S3 bucket, which does not exist on the very first deploy. So I've added initial deploy to npm scripts.
I think something like `npm run deploy:initial`
Also, I've added a basic test to check is AWS user has sufficient permissions to deploy this lambda function at all. I checked only S3 permissions so far, but in the future, the test could check all necessary AWS permissions for deploy.
If you are OK with this PR I can update Readme as well.